### PR TITLE
Add log.debug option to properties file

### DIFF
--- a/src/main/java/net/vexelon/currencybg/srv/Bootstrap.java
+++ b/src/main/java/net/vexelon/currencybg/srv/Bootstrap.java
@@ -8,6 +8,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,6 +45,13 @@ public class Bootstrap {
 			GlobalConfig.INSTANCE.createDefault(configFile, executor);
 		} else {
 			GlobalConfig.INSTANCE.load(configFile, executor);
+		}
+
+		// apply log non-production log level, if needed
+		if (GlobalConfig.INSTANCE.isLogDebugEnabled()) {
+			LogManager.getLogger(Defs.LOGGER_NAME).setLevel(Level.TRACE);
+			LogManager.getRootLogger().setLevel(Level.TRACE);
+			log.trace("**Non-production** TRACE logging mode enabled.");
 		}
 
 		// verify configuration

--- a/src/main/java/net/vexelon/currencybg/srv/Defs.java
+++ b/src/main/java/net/vexelon/currencybg/srv/Defs.java
@@ -8,6 +8,8 @@ import javax.ws.rs.core.MediaType;
  */
 public final class Defs {
 
+	public static final String LOGGER_NAME = "net.vexelon.currencybg";
+
 	/*
 	 * DateTime
 	 */

--- a/src/main/java/net/vexelon/currencybg/srv/GlobalConfig.java
+++ b/src/main/java/net/vexelon/currencybg/srv/GlobalConfig.java
@@ -14,7 +14,7 @@ import org.apache.commons.configuration2.reloading.PeriodicReloadingTrigger;
 import com.google.common.base.Charsets;
 
 /**
- * 
+ * Global server configurations
  *
  */
 public enum GlobalConfig {
@@ -32,7 +32,8 @@ public enum GlobalConfig {
 		MAINTENANCE_ENABLED("maintenance.enabled"),
 		TELEGRAM_BOT_TOKEN("telegram.bot"),
 		TELEGRAM_CHANNEL("telegram.channel"),
-		ENABLE_LOG_SQL("log.sql");
+		ENABLE_LOG_SQL("log.sql"),
+		ENABLE_LOG_DEBUG("log.debug");
 
 		private String optName;
 
@@ -58,6 +59,7 @@ public enum GlobalConfig {
 			setBotToken("");
 			setBotChannel("");
 			setLogSqlEnabled(false);
+			setLogDebugEnabled(false);
 
 			builder.save();
 			builder.setAutoSave(true);
@@ -171,19 +173,27 @@ public enum GlobalConfig {
 		getConfig().setProperty(Options.TELEGRAM_CHANNEL.getName(), channel);
 	}
 
-	/**
-	 * 
-	 * @return
-	 */
 	public boolean isLogSqlEnabled() {
 		return getConfig().getBoolean(Options.ENABLE_LOG_SQL.getName());
 	}
 
 	/**
 	 * 
-	 * @param channel
+	 * @param enabled
 	 */
 	public void setLogSqlEnabled(boolean enabled) {
 		getConfig().setProperty(Options.ENABLE_LOG_SQL.getName(), enabled);
+	}
+
+	public boolean isLogDebugEnabled() {
+		return getConfig().getBoolean(Options.ENABLE_LOG_DEBUG.getName());
+	}
+
+	/**
+	 * 
+	 * @param enabled
+	 */
+	public void setLogDebugEnabled(boolean enabled) {
+		getConfig().setProperty(Options.ENABLE_LOG_DEBUG.getName(), enabled);
 	}
 }

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,7 +1,7 @@
 # Log4J configuration
 ######################
 
-log4j.rootCategory=TRACE, localConsole
+log4j.rootCategory=DEBUG, localConsole
 
 ##############
 log4j.appender.localConsole=org.apache.log4j.ConsoleAppender
@@ -11,8 +11,8 @@ log4j.appender.localConsole.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss,SSS}
 #log4j.appender.localConsole.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
 ##############
 
-# All group classes - go TRACE
-log4j.logger.net.vexelon.currencybg=TRACE
+# All group classes
+log4j.logger.net.vexelon.currencybg=INFO
 
 log4j.logger.org.apache.log4j=off
 log4j.logger.httpclient=off


### PR DESCRIPTION
Добавено ново property `log.debug`, за да можем да контролираме  logging нивото на тест и production сървърите.

----------------

When set to 'true', it will log TRACE and DEBUG messages. (Test)

When set to 'false' only INFO and upper log level messages. (Production)