### PR TITLE
Release jdbc drivers and stop connection thread(s)

### DIFF
--- a/src/main/java/net/vexelon/currencybg/srv/servlets/MyServletContextListener.java
+++ b/src/main/java/net/vexelon/currencybg/srv/servlets/MyServletContextListener.java
@@ -1,10 +1,15 @@
 package net.vexelon.currencybg.srv.servlets;
 
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.util.Enumeration;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
+
+import com.mysql.jdbc.AbandonedConnectionCleanupThread;
 
 import net.vexelon.currencybg.srv.Bootstrap;
 
@@ -34,10 +39,30 @@ public class MyServletContextListener implements ServletContextListener {
 
 		bootstrap.stop();
 
+		// release threads
 		final ScheduledExecutorService executor = (ScheduledExecutorService) sce.getServletContext()
-				.getAttribute(THREAD_POOL_ALIAS);
+		        .getAttribute(THREAD_POOL_ALIAS);
 		if (executor != null) {
+			System.out.println("*** Shutting down threads ***");
 			executor.shutdown();
+		}
+
+		// release database driver(s)
+		// @see http://stackoverflow.com/a/16467695
+		try {
+			AbandonedConnectionCleanupThread.shutdown();
+		} catch (Throwable e) {
+			// do nothing
+		}
+
+		Enumeration<Driver> drivers = DriverManager.getDrivers();
+		while (drivers.hasMoreElements()) {
+			Driver driver = drivers.nextElement();
+			try {
+				DriverManager.deregisterDriver(driver);
+			} catch (Exception e) {
+				System.err.println("*** Failed to unregister sql driver -" + driver.toString() + "! ***");
+			}
 		}
 	}
 


### PR DESCRIPTION
Tomcat actually will release the drivers itself, but in our case we expect to run a single app
in the container, therefore it is safe to release the drivers manually.

Should we run the app in a JEE container and **not Tomcat**, this code **must** be removed!