### PR TITLE
fix_problem_with_reporters_table

### DIFF
--- a/src/main/java/net/vexelon/currencybg/srv/db/MySQLDataSource.java
+++ b/src/main/java/net/vexelon/currencybg/srv/db/MySQLDataSource.java
@@ -590,7 +590,7 @@ public class MySQLDataSource implements DataSource {
 	@Override
 	public void addReport(String message) throws DataSourceException {
 
-		String insertSQL = "INSERT INTO cbg_reports (message) VALUES (?)";
+		String insertSQL = "INSERT INTO cbg_reports (message, createdon) VALUES (?,now())";
 
 		if (log.isTraceEnabled() && isLogSql) {
 			log.trace("[SQL] {}", insertSQL);


### PR DESCRIPTION
В локалната ми версия беше имплементирано да се подава само съобщението в таблицата cbg_reports, а датата да се set-ва по-подразбиране в базата. При опит за качване на скрипта ми даде грешка в phpMyAdmin (#1067 - Invalid default value for 'createdon'), след research в нета видях следното:
"__CURRENT_TIMESTAMP is only acceptable on TIMESTAMP fields. DATETIME fields must be left either with a null default value, or no default value at all_"_ 
Премахнах стойността по-подразбиране от колоната в таблицата и я направих да се подава в SQLStatement
Сега таблицата се качи и нещата изглежда да работят:
![default](https://cloud.githubusercontent.com/assets/8929789/24580602/426f3fa6-1713-11e7-9e19-fc9620634cf4.png)
