### PR TITLE
Üsed withZoneSameLocal(ZoneId instead of withZoneSameInstant

### DIFF
--- a/src/main/java/net/vexelon/currencybg/srv/utils/DateTimeUtilsNew.java
+++ b/src/main/java/net/vexelon/currencybg/srv/utils/DateTimeUtilsNew.java
@@ -1,6 +1,6 @@
 package net.vexelon.currencybg.srv.utils;
 
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
@@ -15,15 +15,7 @@ public class DateTimeUtilsNew {
 	 * @return
 	 */
 	public static String removeTimeZone(String timeFrom, String dateTimeFormatter) {
-		ZonedDateTime fromIsoDate = ZonedDateTime.parse(timeFrom);
-		ZoneOffset offset = ZoneOffset.of("+02:00");
-		ZonedDateTime acst = fromIsoDate.withZoneSameInstant(offset);
-
-		// System.out.println("Input: " + fromIsoDate);
-		// System.out.println("Output: " +
-		// acst.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
-		// System.out.println(DateTimeFormatter.ofPattern("yyyy-MM-dd
-		// HH:mm:ss").format(acst));
-		return DateTimeFormatter.ofPattern(dateTimeFormatter).format(acst);
+		ZonedDateTime fromIsoDate = ZonedDateTime.parse(timeFrom).withZoneSameLocal(ZoneId.of("Europe/Sofia"));
+		return DateTimeFormatter.ofPattern(dateTimeFormatter).format(fromIsoDate);
 	}
 }


### PR DESCRIPTION
Смених метода на ZonedDateTime от withZoneSameInstant на withZoneSameLocal според документацията на Oracle " To change the offset while keeping the local time, use withZoneSameLocal(ZoneId)."
Тествах го с двете зони, в които се сменя времето +02:00 и +03:00 и изглежда да работи 

-  +02:00
![default](https://cloud.githubusercontent.com/assets/8929789/25100472/e3244fde-23b8-11e7-8470-1a6e25a63523.png)

- +03:00
![default](https://cloud.githubusercontent.com/assets/8929789/25100498/035a4060-23b9-11e7-9064-ed7e849c4221.png)
