### PR TITLE
Replace all unicode characters instead of splitting by empty spaces

### DIFF
--- a/src/main/java/net/vexelon/currencybg/srv/remote/CryptoBankSource.java
+++ b/src/main/java/net/vexelon/currencybg/srv/remote/CryptoBankSource.java
@@ -9,7 +9,10 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.http.HttpResponse;
 import org.jsoup.Jsoup;
@@ -30,133 +33,138 @@ import net.vexelon.currencybg.srv.utils.DateTimeUtils;
 
 public class CryptoBankSource extends AbstractSource {
 
-	private static final Logger log = LoggerFactory.getLogger(CryptoBankSource.class);
-	private static final String TAG_NAME = CryptoBankSource.class.getSimpleName();
+    private static final Logger log = LoggerFactory.getLogger(CryptoBankSource.class);
+    private static final String TAG_NAME = CryptoBankSource.class.getSimpleName();
 
-	private static final String URL_SOURCE = "https://cryptobank.bg/index.php";
-	private static final String DATE_FORMAT = "dd.MM.yyyy HH:mm";
+    private static final String URL_SOURCE = "https://cryptobank.bg/index.php";
+    private static final String DATE_FORMAT = "dd.MM.yyyy HH:mm";
 
-	private String htmlData;
+    private String htmlData;
 
-	public CryptoBankSource(Reporter reporter) {
-		super(reporter);
-	}
+    public CryptoBankSource(Reporter reporter) {
+        super(reporter);
+    }
 
-	/**
-	 * Transforms Crypto Bank HTML data into {@link CurrencyData} models.
-	 * 
-	 * @param input
-	 * @return
-	 * @throws IOException
-	 * @throws ParseException
-	 */
-	public List<CurrencyData> getCryptoBankRates(InputStream input) throws IOException, ParseException {
-		List<CurrencyData> result = Lists.newArrayList();
+    /**
+     * Transforms Crypto Bank HTML data into {@link CurrencyData} models.
+     *
+     * @param input
+     * @return
+     * @throws IOException
+     * @throws ParseException
+     */
+    public List<CurrencyData> getCryptoBankRates(InputStream input) throws IOException, ParseException {
+        List<CurrencyData> result = Lists.newArrayList();
 
-		Document doc = Jsoup.parse(input, Charsets.UTF_8.name(), URL_SOURCE);
-		htmlData = doc.toString(); // debugging
+        Document doc = Jsoup.parse(input, Charsets.UTF_8.name(), URL_SOURCE);
+        htmlData = doc.toString(); // debugging
 
-		try {
-			String currentDateTimeSofia = LocalDateTime.now(ZoneId.of(Defs.DATETIME_TIMEZONE_SOFIA))
-			        .format(DateTimeFormatter.ofPattern(DATE_FORMAT)).toString();
+        try {
+            String currentDateTimeSofia = LocalDateTime.now(ZoneId.of(Defs.DATETIME_TIMEZONE_SOFIA))
+                    .format(DateTimeFormatter.ofPattern(DATE_FORMAT)).toString();
 
-			Date updateDate = DateTimeUtils.parseDate(currentDateTimeSofia, DATE_FORMAT);
+            Date updateDate = DateTimeUtils.parseDate(currentDateTimeSofia, DATE_FORMAT);
 
-			// Parse table with currencies
-			Element span = doc.select("div.jsn-modulecontent > table > tbody").get(1);
-			Elements spanContent = span.children();
-			int counter = 0;
-			CurrencyData currencyData = new CurrencyData();
-			String currency;
-			for (Element element : spanContent) {
-				if (counter > 0) {
-					currency = element.child(0).select("td > a > img").attr("alt").split(" ")[0];
-					switch (currency) {
-					case "bitcoin":
-						currencyData.setCode(Defs.CURRENCY_BITCOIN);
-						break;
-					case "ether":
-						currencyData.setCode(Defs.CURRENCY_ETHERIUM);
-						break;
-					case "litecoin":
-						currencyData.setCode(Defs.CURRENCY_LITECOIN);
-						break;
-					case "bitcoin cash":
-						currencyData.setCode(Defs.CURRENCY_BITCOIN_CASH);
-						break;
-					case "dash":
-						currencyData.setCode(Defs.CURRENCY_DASH);
-						break;
-					case "dogecoin":
-						currencyData.setCode(Defs.CURRENCY_DOGECOIN);
-						break;
-					}
-					// The Replace statement(.replace(",", "")) have been made
-					// for BTC to change the format from 6,959.60 to 6959.60
-					currencyData.setBuy(element.child(1).text().substring(0, element.child(1).text().indexOf(" "))
-					        .replace(",", ""));
-					currencyData.setSell(element.child(2).text().substring(0, element.child(2).text().indexOf(" "))
-					        .replace(",", ""));
-					currencyData.setRatio(1);
-					currencyData.setSource(Sources.CRYPTOBANK.getID());
-					currencyData.setDate(updateDate);
-					result.add(currencyData);
+            // Parse table with currencies
+            Element span = doc.select("div.jsn-modulecontent > table > tbody").get(1);
+            Elements spanContent = span.children();
+            int counter = 0;
 
-					currencyData = new CurrencyData();
-				}
-				counter++;
-			}
+            CurrencyData currencyData = new CurrencyData();
 
-			return normalizeCurrencyData(result);
-		} catch (RuntimeException e) {
-			throw new IOException(e);
-		}
-	}
+            for (Element element : spanContent) {
+                if (counter > 0) {
+                    String alt = element.child(0).select("td > a > img").attr("alt");
+                    String currency = StringUtils.trimToEmpty(alt.replaceAll("\\P{Print}", ""));
+                    // currency = element.child(0).select("td > a > img").attr("alt").split(" ")[0];
+                    
+                    switch (currency) {
+                        case "bitcoin":
+                            currencyData.setCode(Defs.CURRENCY_BITCOIN);
+                            break;
+                        case "ether":
+                            currencyData.setCode(Defs.CURRENCY_ETHERIUM);
+                            break;
+                        case "litecoin":
+                            currencyData.setCode(Defs.CURRENCY_LITECOIN);
+                            break;
+                        case "bitcoin cash":
+                            currencyData.setCode(Defs.CURRENCY_BITCOIN_CASH);
+                            break;
+                        case "dash":
+                            currencyData.setCode(Defs.CURRENCY_DASH);
+                            break;
+                        case "dogecoin":
+                            currencyData.setCode(Defs.CURRENCY_DOGECOIN);
+                            break;
+                    }
+                    // The Replace statement(.replace(",", "")) have been made
+                    // for BTC to change the format from 6,959.60 to 6959.60
+                    currencyData.setBuy(element.child(1).text().substring(0, element.child(1).text().indexOf(" "))
+                            .replace(",", ""));
+                    currencyData.setSell(element.child(2).text().substring(0, element.child(2).text().indexOf(" "))
+                            .replace(",", ""));
+                    currencyData.setRatio(1);
+                    currencyData.setSource(Sources.CRYPTOBANK.getID());
+                    currencyData.setDate(updateDate);
+                    result.add(currencyData);
 
-	@Override
-	public void getRates(Callback callback) throws SourceException {
-		try {
-			doGet(URL_SOURCE, new HTTPCallback() {
+                    currencyData = new CurrencyData();
+                }
 
-				@Override
-				public void onRequestFailed(Exception e) {
-					getReporter().write(TAG_NAME, "Connection failure= {}", ExceptionUtils.getStackTrace(e));
+                counter++;
+            }
 
-					CryptoBankSource.this.close();
-					callback.onFailed(e);
-				}
+            return normalizeCurrencyData(result);
+        } catch (RuntimeException e) {
+            throw new IOException(e);
+        }
+    }
 
-				@Override
-				public void onRequestCompleted(HttpResponse response, boolean isCanceled) {
-					List<CurrencyData> result = Lists.newArrayList();
+    @Override
+    public void getRates(Callback callback) throws SourceException {
+        try {
+            doGet(URL_SOURCE, new HTTPCallback() {
 
-					if (!isCanceled) {
-						try {
+                @Override
+                public void onRequestFailed(Exception e) {
+                    getReporter().write(TAG_NAME, "Connection failure= {}", ExceptionUtils.getStackTrace(e));
 
-							result = getCryptoBankRates(response.getEntity().getContent());
-						} catch (IOException | ParseException e) {
-							log.error("Could not parse source data!", e);
-							getReporter().write(TAG_NAME, "Parse failed= {}  HTML= {}", ExceptionUtils.getStackTrace(e),
-			                        htmlData);
-						}
-					} else {
-						log.warn("Request was canceled! No currencies were downloaded.");
-						getReporter().write(TAG_NAME, "Request was canceled! No currencies were downloaded.");
-					}
+                    CryptoBankSource.this.close();
+                    callback.onFailed(e);
+                }
 
-					CryptoBankSource.this.close();
-					callback.onCompleted(result);
-				}
-			});
-		} catch (URISyntaxException e) {
-			throw new SourceException("Invalid source url - " + URL_SOURCE, e);
-		}
+                @Override
+                public void onRequestCompleted(HttpResponse response, boolean isCanceled) {
+                    List<CurrencyData> result = Lists.newArrayList();
 
-	}
+                    if (!isCanceled) {
+                        try {
 
-	@Override
-	public String getName() {
-		return TAG_NAME;
-	}
+                            result = getCryptoBankRates(response.getEntity().getContent());
+                        } catch (IOException | ParseException e) {
+                            log.error("Could not parse source data!", e);
+                            getReporter().write(TAG_NAME, "Parse failed= {}  HTML= {}", ExceptionUtils.getStackTrace(e),
+                                    htmlData);
+                        }
+                    } else {
+                        log.warn("Request was canceled! No currencies were downloaded.");
+                        getReporter().write(TAG_NAME, "Request was canceled! No currencies were downloaded.");
+                    }
+
+                    CryptoBankSource.this.close();
+                    callback.onCompleted(result);
+                }
+            });
+        } catch (URISyntaxException e) {
+            throw new SourceException("Invalid source url - " + URL_SOURCE, e);
+        }
+
+    }
+
+    @Override
+    public String getName() {
+        return TAG_NAME;
+    }
 
 }


### PR DESCRIPTION
Тествах сървъра преди малко и се оказа, че заради split по празно място, bitcoin cash не се parse-ва както трябва. 

Тоя фикс маха всички unicode символи, така че да остане само латинското име и после да мине проверката. 

Ref #97 

_(нещо заради space-овете се омаза diff-a на целият файл)_